### PR TITLE
Fix the segfault we were getting on launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 boot: l00interpreter.cpp l00interpreter.py
 	g++ -ggdb -std=c++11 -Wall -Wextra -pedantic l00interpreter.cpp -o l00interpreter
 	./l00interpreter l01compiler.tbf1 < l01compiler.tbf1 > l01compiler
-	python l00interpreter.py l01compiler.tbf1 < l01compiler.tbf1 > l01compiler-py
+	./l00interpreter.py l01compiler.tbf1 < l01compiler.tbf1 > l01compiler-py
 	@diff l01compiler l01compiler-py || ( echo "l01compiler differs between c++/py" && exit 1 )
 	@chmod +x l01compiler && rm l01compiler-py

--- a/l00interpreter.py
+++ b/l00interpreter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """Tiny bootstrapping interpreter for the first bootstrap stage.
 

--- a/l01compiler.tbf1
+++ b/l01compiler.tbf1
@@ -202,14 +202,14 @@ Directory of magic numbers used, other than 0 and 1:
 237 — second byte of `sub $xxx, %ebp`
 254 — first byte of `dec %al`
 1024 — a table size in bytes: 256 entries of 4 bytes each
-4096 — the program runs with its origin at 4096, 0x1000, because that still 
-       leaves hex addresses easy to type and read, while leaving it likely 
-       that null pointer references will crash the program rather than making
-       mysterious bugs.  Also there’s a buffer of this size, which will go 
-       away soon.
+4096 — there’s a buffer of this size, which will go away soon.
 6144 — 6 * 1024: the offset at which a couple of 1024-byte tables are 
        constructed, ending just before the compiled program itself.
 8192 — the offset at which the compiler constructs the compiled program.
+131072 — the program runs with its origin at 0x20000. We can't go lower than
+         0x10000 on new kernels unless we change the vm.mmap_min_addr sysctl
+         parameter. Give ourselves a comfortable margin above that while
+         still keeping addresses relatively short.
 655360 — the total memory space allocated for the program
 
 Register-use conventions:
@@ -248,7 +248,7 @@ var header ( ELF header, Elf32_Ehdr )
 ( Program header, Elf32_Phdr; note that we are now 52 bytes from `header`. )
       ( p_type:) # 1              ( p_offset:) # 0 
      ( p_paddr should be 0, not equal to p_vaddr as Brian has)
-     ( p_vaddr:) var origin # 4096 ( p_paddr:) # 0
+     ( p_vaddr:) var origin # 131072 ( p_paddr:) # 0
 ( Note that you can only make `p_memsz` as large as you want if `p_flags` has a
   2 = `PF_W` in it.  Otherwise, even one extra byte results in a segfault.
   655360 bytes should be enough for anyone. )


### PR DESCRIPTION
Linux has a tunable, `vm.mmap_min_addr`, which specifies an address below which memory mapping is prohibited for unprivileged users. New kernels set this tunable quite high—well above the load address of `1024` that this project used. Increase our load address to `131072` (`0x20000`) to stop the ELF loader from killling us.

Also, fix up the Python invocation in the `Makefile` to work on distros where Python 3 is the default.